### PR TITLE
Add title support

### DIFF
--- a/dist/amChartsDirective.js
+++ b/dist/amChartsDirective.js
@@ -185,6 +185,13 @@ angular.module('amChartsDirective', []).directive('amChart', ['$q', function ($q
                 generateGraphProperties();
               }
 
+              if (o.titles) {
+                for (var i = 0;i < o.titles.length;i++) {
+                  var title = o.titles[i];
+                  chart.addTitle(title.text, title.size, title.color, title.alpha, title.bold);
+                });
+              }
+
               // WRITE
               chart.write(id);
 


### PR DESCRIPTION
For some reason using titles in the chart config doesn't cause the titles to be rendered.  This will allow them to be added.
