### PR TITLE
Add attribute for a promise-based set of options

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,24 @@ $scope.amChartOptions = {
     }
 ```
     
+#### Example using promises
+
+```javascript
+var deferredOptions = $q.defer();
+var deferredData = $q.defer();
+
+$scope.amChartOptions = { promise: deferredOptions.promise };
+
+myService.then(function() {
+	deferredOptions.resolve({
+		type: "serial",
+		data: deferredData.promise,
+		etc: 'etc'
+	});
+	myOtherService.then(function(data) {
+		deferredData.resolve(data);
+	});
+});
     
 ##### If you do not specify a category field or a value field, the directive will assume the category field is at index [0] and the value field is at index [1]. Using the example above, 'year' would be the category field, and 'income' would be the value field.
     

--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ $scope.amChartOptions = {
     
 #### Example using promises
 
+``` html
+<am-chart id="myFirstChart" options-promise="amChartOptions" height="100%" width="100%"></am-chart>
+```
+
 ```javascript
 var deferredOptions = $q.defer();
 var deferredData = $q.defer();

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ myService.then(function() {
 		deferredData.resolve(data);
 	});
 });
+```
     
 ##### If you do not specify a category field or a value field, the directive will assume the category field is at index [0] and the value field is at index [1]. Using the example above, 'year' would be the category field, and 'income' would be the value field.
     

--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,7 @@
     "tests"
   ],
   "dependencies": {
-    "amcharts": "~3.13.0"
+    "amcharts": "~3.13.0",
+    "angular": ">=1.3.0"
   }
 }

--- a/dist/amChartsDirective.js
+++ b/dist/amChartsDirective.js
@@ -18,7 +18,7 @@ angular.module('amChartsDirective', []).directive('amChart', ['$q', function ($q
       $el.attr('id', id);
       var chart;
 
-			function setup(chartOptions) {
+      function setup(chartOptions) {
       // we can't render a chart without any data
         var renderChart = function (amChartOptions) {
           var o = amChartOptions || $scope.options;

--- a/dist/amChartsDirective.js
+++ b/dist/amChartsDirective.js
@@ -18,8 +18,8 @@ angular.module('amChartsDirective', []).directive('amChart', ['$q', function ($q
       $el.attr('id', id);
       var chart;
 
+			function setup(chartOptions) {
       // we can't render a chart without any data
-      if ($scope.options.data) {
         var renderChart = function (amChartOptions) {
           var o = amChartOptions || $scope.options;
 
@@ -228,6 +228,14 @@ angular.module('amChartsDirective', []).directive('amChart', ['$q', function ($q
           if (id === $el[0].id || !id) {
             renderChart(amChartOptions);
           }
+        });
+      }
+
+      if ($scope.options) {
+        setup($scope.options);
+      } else if ($scope.optionsPromise) {
+        $q.when($scope.optionsPromise.promise).then(function(chartOptions) {
+          setup(chartOptions);
         });
       }
     }

--- a/dist/amChartsDirective.js
+++ b/dist/amChartsDirective.js
@@ -20,215 +20,217 @@ angular.module('amChartsDirective', []).directive('amChart', ['$q', function ($q
 
       function setup(chartOptions) {
       // we can't render a chart without any data
-        var renderChart = function (amChartOptions) {
-          var o = amChartOptions || $scope.options;
+				if (chartOptions && chartOptions.data) {
+          var renderChart = function (amChartOptions) {
+            var o = amChartOptions || $scope.options;
 
-          // set height and width
-          var height = $scope.height || '100%';
-          var width = $scope.width || '100%';
+            // set height and width
+            var height = $scope.height || '100%';
+            var width = $scope.width || '100%';
 
-          $el.css({
-            'height': height,
-            'width': width
-          });
+            $el.css({
+              'height': height,
+              'width': width
+            });
 
-          // instantiate new chart object
-          if (o.type === 'xy') {
-            chart = o.theme ? new AmCharts.AmXYChart(AmCharts.themes[o.theme]) : new AmCharts.AmXYChart();
-          } else if (o.type === 'pie') {
-            chart = o.theme ? new AmCharts.AmPieChart(AmCharts.themes[o.theme]) : new AmCharts.AmPieChart();
-          } else {
-            chart = o.theme ? new AmCharts.AmSerialChart(AmCharts.themes[o.theme]) : new AmCharts.AmSerialChart();
-          }
+            // instantiate new chart object
+            if (o.type === 'xy') {
+              chart = o.theme ? new AmCharts.AmXYChart(AmCharts.themes[o.theme]) : new AmCharts.AmXYChart();
+            } else if (o.type === 'pie') {
+              chart = o.theme ? new AmCharts.AmPieChart(AmCharts.themes[o.theme]) : new AmCharts.AmPieChart();
+            } else {
+              chart = o.theme ? new AmCharts.AmSerialChart(AmCharts.themes[o.theme]) : new AmCharts.AmSerialChart();
+            }
 
-          /** set some default values that amCharts doesnt provide **/
-          $q.when(o.data)
-            .then(function (data) {
+            /** set some default values that amCharts doesnt provide **/
+            $q.when(o.data)
+              .then(function (data) {
 
-              chart.dataProvider = data;
-              // if a category field is not specified, attempt to use the first field from an object in the array
-              chart.categoryField = o.categoryField || Object.keys(o.data[0])[0];
-              chart.startDuration = 0.5; // default animation length, because everyone loves a little pizazz
+                chart.dataProvider = data;
+                // if a category field is not specified, attempt to use the first field from an object in the array
+                chart.categoryField = o.categoryField || Object.keys(o.data[0])[0];
+                chart.startDuration = 0.5; // default animation length, because everyone loves a little pizazz
 
-              // AutoMargin is on by default, but the default 20px all around seems to create unnecessary white space around the control
-              chart.autoMargins = true;
-              chart.marginTop = 0;
-              chart.marginLeft = 0;
-              chart.marginBottom = 0;
-              chart.marginRight = 0;
+                // AutoMargin is on by default, but the default 20px all around seems to create unnecessary white space around the control
+                chart.autoMargins = true;
+                chart.marginTop = 0;
+                chart.marginLeft = 0;
+                chart.marginBottom = 0;
+                chart.marginRight = 0;
 
-              // modify default creditsPosition
-              chart.creditsPosition = 'top-right';
+                // modify default creditsPosition
+                chart.creditsPosition = 'top-right';
 
-              var chartKeys = Object.keys(o);
-              for (var i = 0; i < chartKeys.length; i++) {
-                if (typeof o[chartKeys[i]] !== 'object' && typeof o[chartKeys[i]] !== 'function') {
-                  chart[chartKeys[i]] = o[chartKeys[i]];
+                var chartKeys = Object.keys(o);
+                for (var i = 0; i < chartKeys.length; i++) {
+                  if (typeof o[chartKeys[i]] !== 'object' && typeof o[chartKeys[i]] !== 'function') {
+                    chart[chartKeys[i]] = o[chartKeys[i]];
+                  }
                 }
-              }
 
-              function generateGraphProperties(data) {
-                // Assign Category Axis Properties
-                if (o.categoryAxis) {
-                  var categoryAxis = chart.categoryAxis;
+                function generateGraphProperties(data) {
+                  // Assign Category Axis Properties
+                  if (o.categoryAxis) {
+                    var categoryAxis = chart.categoryAxis;
 
-                  if (categoryAxis) {
-                    /* if we need to create any default values, we should assign them here */
-                    categoryAxis.parseDates = true;
+                    if (categoryAxis) {
+                      /* if we need to create any default values, we should assign them here */
+                      categoryAxis.parseDates = true;
 
-                    var keys = Object.keys(o.categoryAxis);
+                      var keys = Object.keys(o.categoryAxis);
+                      for (var i = 0; i < keys.length; i++) {
+                        if (!angular.isObject(o.categoryAxis[keys[i]]) || angular.isArray(o.categoryAxis[keys[i]])) {
+                          categoryAxis[keys[i]] = o.categoryAxis[keys[i]];
+                        } else {
+                          console.log('Stripped categoryAxis obj ' + keys[i]);
+                        }
+                      }
+                      chart.categoryAxis = categoryAxis;
+                    }
+                  }
+
+                  // Create value axis
+
+                  /* if we need to create any default values, we should assign them here */
+
+                  var addValueAxis = function (a) {
+                    var valueAxis = new AmCharts.ValueAxis();
+
+                    var keys = Object.keys(a);
                     for (var i = 0; i < keys.length; i++) {
-                      if (!angular.isObject(o.categoryAxis[keys[i]]) || angular.isArray(o.categoryAxis[keys[i]])) {
-                        categoryAxis[keys[i]] = o.categoryAxis[keys[i]];
-                      } else {
-                        console.log('Stripped categoryAxis obj ' + keys[i]);
+                      if (typeof a[keys[i]] !== 'object') {
+                        valueAxis[keys[i]] = a[keys[i]];
                       }
                     }
-                    chart.categoryAxis = categoryAxis;
-                  }
-                }
+                    chart.addValueAxis(valueAxis);
+                  };
 
-                // Create value axis
-
-                /* if we need to create any default values, we should assign them here */
-
-                var addValueAxis = function (a) {
-                  var valueAxis = new AmCharts.ValueAxis();
-
-                  var keys = Object.keys(a);
-                  for (var i = 0; i < keys.length; i++) {
-                    if (typeof a[keys[i]] !== 'object') {
-                      valueAxis[keys[i]] = a[keys[i]];
+                  if (o.valueAxes && o.valueAxes.length > 0) {
+                    for (var i = 0; i < o.valueAxes.length; i++) {
+                      addValueAxis(o.valueAxes[i]);
                     }
                   }
-                  chart.addValueAxis(valueAxis);
-                };
 
-                if (o.valueAxes && o.valueAxes.length > 0) {
-                  for (var i = 0; i < o.valueAxes.length; i++) {
-                    addValueAxis(o.valueAxes[i]);
+
+                  //reusable function to create graph
+                  var addGraph = function (g) {
+                    var graph = new AmCharts.AmGraph();
+                    /** set some default values that amCharts doesnt provide **/
+                      // if a category field is not specified, attempt to use the second field from an object in the array as a default value
+                    graph.valueField = g.valueField || Object.keys(o.data[0])[1];
+                    graph.balloonText = '<span style="font-size:14px">[[category]]: <b>[[value]]</b></span>';
+                    if (g) {
+                      var keys = Object.keys(g);
+                      // iterate over all of the properties in the graph object and apply them to the new AmGraph
+                      for (var i = 0; i < keys.length; i++) {
+                        graph[keys[i]] = g[keys[i]];
+                      }
+                    }
+                    chart.addGraph(graph);
+                  };
+
+                  // create the graphs
+                  if (o.graphs && o.graphs.length > 0) {
+                    for (var i = 0; i < o.graphs.length; i++) {
+                      addGraph(o.graphs[i]);
+                    }
+                  } else {
+                    addGraph();
                   }
-                }
 
-
-                //reusable function to create graph
-                var addGraph = function (g) {
-                  var graph = new AmCharts.AmGraph();
-                  /** set some default values that amCharts doesnt provide **/
-                    // if a category field is not specified, attempt to use the second field from an object in the array as a default value
-                  graph.valueField = g.valueField || Object.keys(o.data[0])[1];
-                  graph.balloonText = '<span style="font-size:14px">[[category]]: <b>[[value]]</b></span>';
-                  if (g) {
-                    var keys = Object.keys(g);
-                    // iterate over all of the properties in the graph object and apply them to the new AmGraph
+                  var chartCursor = new AmCharts.ChartCursor();
+                  if (o.chartCursor) {
+                    var keys = Object.keys(o.chartCursor);
                     for (var i = 0; i < keys.length; i++) {
-                      graph[keys[i]] = g[keys[i]];
+                      if (typeof o.chartCursor[keys[i]] !== 'object') {
+                        chartCursor[keys[i]] = o.chartCursor[keys[i]];
+                      }
                     }
                   }
-                  chart.addGraph(graph);
-                };
+                  chart.addChartCursor(chartCursor);
 
-                // create the graphs
-                if (o.graphs && o.graphs.length > 0) {
-                  for (var i = 0; i < o.graphs.length; i++) {
-                    addGraph(o.graphs[i]);
+                  if (o.chartScrollbar) {
+                    var scrollbar = new AmCharts.ChartScrollbar();
+                    var keys = Object.keys(o.chartScrollbar);
+                    for (var i = 0; i < keys.length; i++) {
+                      scrollbar[keys[i]] = o.chartScrollbar[keys[i]];
+                    }
+                    chart.chartScrollbar = scrollbar;
                   }
+
+                  if (o.balloon) {
+                    chart.balloon = o.balloon;
+                  }
+                }
+
+                function generatePieProperties() {
+                  if (o.balloon) {
+                    chart.balloon = o.balloon;
+                  }
+                }
+
+                if (o.legend) {
+                  var legend = new AmCharts.AmLegend();
+                  var keys = Object.keys(o.legend);
+                  for (var i = 0; i < keys.length; i++) {
+                    legend[keys[i]] = o.legend[keys[i]];
+                  }
+                  chart.legend = legend;
+                }
+
+                if (o.type === 'pie') {
+                  generatePieProperties();
                 } else {
-                  addGraph();
+                  generateGraphProperties();
                 }
 
-                var chartCursor = new AmCharts.ChartCursor();
-                if (o.chartCursor) {
-                  var keys = Object.keys(o.chartCursor);
-                  for (var i = 0; i < keys.length; i++) {
-                    if (typeof o.chartCursor[keys[i]] !== 'object') {
-                      chartCursor[keys[i]] = o.chartCursor[keys[i]];
-                    }
-                  }
-                }
-                chart.addChartCursor(chartCursor);
-
-                if (o.chartScrollbar) {
-                  var scrollbar = new AmCharts.ChartScrollbar();
-                  var keys = Object.keys(o.chartScrollbar);
-                  for (var i = 0; i < keys.length; i++) {
-                    scrollbar[keys[i]] = o.chartScrollbar[keys[i]];
-                  }
-                  chart.chartScrollbar = scrollbar;
+                if (o.titles) {
+                  for (var i = 0;i < o.titles.length;i++) {
+                    var title = o.titles[i];
+                    chart.addTitle(title.text, title.size, title.color, title.alpha, title.bold);
+                  };
                 }
 
-                if (o.balloon) {
-                  chart.balloon = o.balloon;
-                }
-              }
+                // WRITE
+                chart.write(id);
 
-              function generatePieProperties() {
-                if (o.balloon) {
-                  chart.balloon = o.balloon;
-                }
-              }
-
-              if (o.legend) {
-                var legend = new AmCharts.AmLegend();
-                var keys = Object.keys(o.legend);
-                for (var i = 0; i < keys.length; i++) {
-                  legend[keys[i]] = o.legend[keys[i]];
-                }
-                chart.legend = legend;
-              }
-
-              if (o.type === 'pie') {
-                generatePieProperties();
-              } else {
-                generateGraphProperties();
-              }
-
-              if (o.titles) {
-                for (var i = 0;i < o.titles.length;i++) {
-                  var title = o.titles[i];
-                  chart.addTitle(title.text, title.size, title.color, title.alpha, title.bold);
-                };
-              }
-
-              // WRITE
-              chart.write(id);
-
-            });
-        }; //renderchart
+              });
+          }; //renderchart
 
 
-        // Render the chart
-        renderChart();
+          // Render the chart
+          renderChart();
 
 
-        // EVENTS =========================================================================
+          // EVENTS =========================================================================
 
-        $scope.$on('amCharts.triggerChartAnimate', function (event, id) {
-          if (id === $el[0].id || !id) {
-            chart.animateAgain();
-          }
-        });
+          $scope.$on('amCharts.triggerChartAnimate', function (event, id) {
+            if (id === $el[0].id || !id) {
+              chart.animateAgain();
+            }
+          });
 
-        $scope.$on('amCharts.updateData', function (event, data, id) {
-          if (id === $el[0].id || !id) {
-            chart.dataProvider = data;
-            chart.validateData();
-          }
+          $scope.$on('amCharts.updateData', function (event, data, id) {
+            if (id === $el[0].id || !id) {
+              chart.dataProvider = data;
+              chart.validateData();
+            }
 
-        });
+          });
 
-        $scope.$on('amCharts.validateNow', function (event, validateData, skipEvents, id) {
-          if (id === $el[0].id || !id) {
-            chart.validateNow(validateData === undefined ? true : validateData,
-              skipEvents === undefined ? false : skipEvents);
-          }
-        });
+          $scope.$on('amCharts.validateNow', function (event, validateData, skipEvents, id) {
+            if (id === $el[0].id || !id) {
+              chart.validateNow(validateData === undefined ? true : validateData,
+                skipEvents === undefined ? false : skipEvents);
+            }
+          });
 
-        $scope.$on('amCharts.renderChart', function (event, amChartOptions, id) {
-          if (id === $el[0].id || !id) {
-            renderChart(amChartOptions);
-          }
-        });
+          $scope.$on('amCharts.renderChart', function (event, amChartOptions, id) {
+            if (id === $el[0].id || !id) {
+              renderChart(amChartOptions);
+            }
+          });
+        }
       }
 
       if ($scope.options) {


### PR DESCRIPTION
I added a new attribute called options-promise to solve my issue.  It is used if options isn't there.  I used a new attribute because you can't pass a promise directly to a directive via an attribute - have to use an object field as shown in the README example.
