### PR TITLE
Support adding listeners

### DIFF
--- a/dist/amChartsDirective.js
+++ b/dist/amChartsDirective.js
@@ -200,6 +200,12 @@ angular.module('amChartsDirective', []).directive('amChart', ['$q', function ($q
                   chart.export = o.export;
                 }
 
+                if(o.listeners) {
+                  for (var i = 0; i < o.listeners.length; i++) {
+                    chart.addListener(o.listeners[i].event, o.listeners[i].method);
+                  }
+                }
+
                 // WRITE
                 chart.write(id);
 


### PR DESCRIPTION
Addresses #38 
Adds all listeners defined in the listeners array. Attempted to directly set the listener array but that wasn't working so instead it uses the addListener method.
