### PR TITLE
Fix export property on Chart object for amCharts 3.13.

### DIFF
--- a/dist/amChartsDirective.js
+++ b/dist/amChartsDirective.js
@@ -191,7 +191,7 @@ angular.module('amChartsDirective', []).directive('amChart', ['$q', function ($q
                 }
 
                 if(o.export) {
-                  chart.export = o.export;
+                  chart.amExport = o.export;
                 }
 
                 if(o.colors) {


### PR DESCRIPTION
Property definition was incorrectly referencing the 'export' field on the chart object; when the correct index for amCharts 3.13 is amExport.

Have left the Angular property as Export as this would meant that existing (broken) implementations would start working, and when this is updated to amCharts 3.14 (or later) the property would remain compatible.
