### PR TITLE
added possibility to set id via controller's variables

### DIFF
--- a/dist/amChartsDirective.js
+++ b/dist/amChartsDirective.js
@@ -8,7 +8,8 @@ angular.module('amChartsDirective', []).directive('amChart', ['$q', function ($q
     scope: {
       options: '=',
       height: '@',
-      width: '@'
+      width: '@',
+      id: '@'
     },
     template: '<div class="amchart"></div>',
     link: function ($scope, $el) {
@@ -277,7 +278,7 @@ angular.module('amChartsDirective', []).directive('amChart', ['$q', function ($q
       });
 
       function getIdForUseInAmCharts(){
-        var id = $el[0].id;// try to use existing outer id to create new id
+        var id = $scope.id;// try to use existing outer id to create new id
 
         if (!id){//generate a UUID
           var guid = function guid() {


### PR DESCRIPTION
If we try to use am-chart in ng-repeat cycle without id attribute, all works fine, but if try to set id - charts are not drawn (https://jsfiddle.net/jzoekjwv/). There is a situation when you need to know id's charts, for example you want update certain chart - $scope.$broadcast('amCharts.updateData', newData, rightId)
