### PR TITLE
Expose chart object

### DIFF
--- a/dist/amChartsDirective.js
+++ b/dist/amChartsDirective.js
@@ -7,6 +7,7 @@ angular.module('amChartsDirective', []).directive('amChart', ['$q', function ($q
     replace: true,
     scope: {
       options: '=',
+      chart: '=',
       height: '@',
       width: '@',
       id: '@'
@@ -18,6 +19,7 @@ angular.module('amChartsDirective', []).directive('amChart', ['$q', function ($q
       var id = getIdForUseInAmCharts();
       $el.attr('id', id);
       var chart;
+      $scope.chart = chart;
 
       // allow $scope.options to be a promise
       $q.when($scope.options).then(function(options){
@@ -236,6 +238,7 @@ angular.module('amChartsDirective', []).directive('amChart', ['$q', function ($q
 
                 // WRITE
                 chart.write(id);
+                $scope.chart = chart;
 
               });
           }; //renderchart


### PR DESCRIPTION
Exposing the chart object allows us to manipulate the chart outside what this directive provides. Since amCharts will constantly be adding features it's difficult to always have them supported with this project. I used this to access the zoomToIndexes function of the chart in my project. I think this is a simple solution to get full chart functionality out of this directive.
